### PR TITLE
Pre-release 8.1.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
-    id("com.android.library") version "7.1.0-beta02" apply false
-    kotlin("android") version "1.6.0-RC2" apply false
+    id("com.android.library") version "7.1.2" apply false
+    kotlin("android") version "1.6.10" apply false
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.8.0"
 }
 
 tasks.register<Delete>("clean") {

--- a/locationfetcher/build.gradle.kts
+++ b/locationfetcher/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 apply(from = "$rootDir/scripts/publish-root.gradle.kts")
 
 group = "app.freel"
-version = "8.0.0"
+version = "8.1.0"
 
 android {
     compileSdk = 31
@@ -26,7 +26,7 @@ android {
             "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
         )
         jvmTarget = "1.8"
-        languageVersion = "1.5"
+        languageVersion = "1.6"
     }
 }
 
@@ -42,7 +42,7 @@ afterEvaluate {
             register<MavenPublication>("release") {
                 from(components["release"])
                 groupId = "app.freel"
-                version = "8.0.0"
+                version = "8.1.0"
                 artifactId = project.name
                 artifact(sourcesJar).apply {
                     classifier = "sources"
@@ -84,34 +84,15 @@ signing {
 }
 
 dependencies {
-    coroutines()
-    jetpack()
-    arrow()
-    implementation("com.google.android.gms:play-services-location:18.0.0")
-    implementation("javax.inject:javax.inject:1")
-}
-
-fun DependencyHandlerScope.arrow() {
-    val version = "1.0.1"
-    api("io.arrow-kt:arrow-core:$version")
-}
-
-fun DependencyHandlerScope.coroutines() {
-    val version = "1.5.2"
-    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:$version")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$version")
-}
-
-fun DependencyHandlerScope.jetpack() {
+    api("io.arrow-kt:arrow-core:1.0.1")
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.6.0")
+    implementation("com.google.android.gms:play-services-location:19.0.1")
     implementation("androidx.activity:activity-ktx:1.4.0")
-    implementation("androidx.fragment:fragment-ktx:1.4.0-rc01")
-    implementation("androidx.appcompat:appcompat:1.4.0-rc01")
+    implementation("androidx.fragment:fragment-ktx:1.4.1")
+    implementation("androidx.appcompat:appcompat:1.4.1")
     implementation("androidx.core:core-ktx:1.7.0")
-    androidxLifecycle()
-}
-
-fun DependencyHandlerScope.androidxLifecycle() {
-    val lifecycleVersion = "2.4.0"
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion")
-    implementation("androidx.lifecycle:lifecycle-common:$lifecycleVersion")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.4.1")
+    implementation("androidx.lifecycle:lifecycle-common:2.4.1")
+    implementation("javax.inject:javax.inject:1")
 }

--- a/locationfetcher/src/main/java/com/freelapp/libs/locationfetcher/Builders.kt
+++ b/locationfetcher/src/main/java/com/freelapp/libs/locationfetcher/Builders.kt
@@ -2,30 +2,80 @@ package com.freelapp.libs.locationfetcher
 
 import android.content.Context
 import androidx.activity.ComponentActivity
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.LifecycleOwner
 import com.freelapp.libs.locationfetcher.impl.LocationFetcherImpl
 import com.freelapp.libs.locationfetcher.impl.LocationSourceImpl
 import kotlinx.coroutines.CoroutineScope
 
+public fun Fragment.locationFetcher(
+    rationaleProducer: () -> String,
+    configProducer: LocationFetcher.Config.() -> Unit = { }
+): LocationFetcher =
+    LocationFetcher(
+        this,
+        lazy { LocationFetcher.Config(rationaleProducer()).apply(configProducer) }
+    )
+
+public fun ComponentActivity.locationFetcher(
+    rationaleProducer: () -> String,
+    configProducer: LocationFetcher.Config.() -> Unit = { }
+): LocationFetcher =
+    LocationFetcher(
+        this,
+        lazy { LocationFetcher.Config(rationaleProducer()).apply(configProducer) }
+    )
+
+public fun Context.locationFetcher(
+    owner: LifecycleOwner,
+    rationaleProducer: () -> String,
+    configProducer: LocationFetcher.Config.() -> Unit = { }
+): LocationFetcher =
+    LocationFetcher(
+        this,
+        owner,
+        lazy { LocationFetcher.Config(rationaleProducer()).apply(configProducer) }
+    )
+
+public fun FragmentActivity.locationFetcher(
+    rationale: String,
+    config: LocationFetcher.Config.() -> Unit = { }
+): LocationFetcher =
+    LocationFetcher(this, lazy { LocationFetcher.Config(rationale).apply(config) })
+
+public fun Fragment.locationFetcher(
+    rationale: String,
+    config: LocationFetcher.Config.() -> Unit = { }
+): LocationFetcher =
+    LocationFetcher(this, lazy { LocationFetcher.Config(rationale).apply(config) })
+
 public fun ComponentActivity.locationFetcher(
     rationale: String,
     config: LocationFetcher.Config.() -> Unit = { }
 ): LocationFetcher =
-    LocationFetcher(this, LocationFetcher.Config(rationale).apply(config))
+    LocationFetcher(this, lazy { LocationFetcher.Config(rationale).apply(config) })
 
 public fun Context.locationFetcher(
     owner: LifecycleOwner,
     rationale: String,
     config: LocationFetcher.Config.() -> Unit = { }
 ): LocationFetcher =
-    LocationFetcher(this, owner, LocationFetcher.Config(rationale).apply(config))
+    LocationFetcher(this, owner, lazy { LocationFetcher.Config(rationale).apply(config) })
 
 public fun LocationFetcher(
     activity: ComponentActivity,
     rationale: String,
     config: LocationFetcher.Config.() -> Unit = { }
 ): LocationFetcher =
-    LocationFetcher(activity, LocationFetcher.Config(rationale).apply(config))
+    LocationFetcher(activity, lazy { LocationFetcher.Config(rationale).apply(config) })
+
+public fun LocationFetcher(
+    fragment: Fragment,
+    rationale: String,
+    config: LocationFetcher.Config.() -> Unit = { }
+): LocationFetcher =
+    LocationFetcher(fragment, lazy { LocationFetcher.Config(rationale).apply(config) })
 
 public fun LocationFetcher(
     context: Context,
@@ -33,18 +83,39 @@ public fun LocationFetcher(
     rationale: String,
     config: LocationFetcher.Config.() -> Unit = { }
 ): LocationFetcher =
-    LocationFetcher(context, owner, LocationFetcher.Config(rationale).apply(config))
+    LocationFetcher(context, owner, lazy { LocationFetcher.Config(rationale).apply(config) })
+
+public fun LocationFetcher(
+    activity: ComponentActivity,
+    config: Lazy<LocationFetcher.Config>,
+): LocationFetcher = LocationFetcherImpl(activity, lazy { config.value.copy() })
+
+public fun LocationFetcher(
+    fragment: Fragment,
+    config: Lazy<LocationFetcher.Config>,
+): LocationFetcher = LocationFetcherImpl(fragment, lazy { config.value.copy() })
+
+public fun LocationFetcher(
+    context: Context,
+    owner: LifecycleOwner,
+    config: Lazy<LocationFetcher.Config>
+): LocationFetcher = LocationFetcherImpl(context, owner, lazy { config.value.copy() })
 
 public fun LocationFetcher(
     activity: ComponentActivity,
     config: LocationFetcher.Config,
-): LocationFetcher = LocationFetcherImpl(activity, config.copy())
+): LocationFetcher = LocationFetcherImpl(activity, lazy { config.copy() })
+
+public fun LocationFetcher(
+    fragment: Fragment,
+    config: LocationFetcher.Config,
+): LocationFetcher = LocationFetcherImpl(fragment, lazy { config.copy() })
 
 public fun LocationFetcher(
     context: Context,
     owner: LifecycleOwner,
     config: LocationFetcher.Config
-): LocationFetcher = LocationFetcherImpl(context, owner, config.copy())
+): LocationFetcher = LocationFetcherImpl(context, owner, lazy { config.copy() })
 
 public fun LocationSource(
     scope: CoroutineScope,

--- a/locationfetcher/src/main/java/com/freelapp/libs/locationfetcher/impl/entity/ApiHolder.kt
+++ b/locationfetcher/src/main/java/com/freelapp/libs/locationfetcher/impl/entity/ApiHolder.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.location.LocationManager
 import androidx.activity.ComponentActivity
 import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import com.freelapp.libs.locationfetcher.impl.dsl.locationSettingsRequest
 import com.freelapp.libs.locationfetcher.impl.util.awaitComplete
@@ -19,6 +20,7 @@ internal suspend inline operator fun <T> Flow<ApiHolder?>.invoke(block: ApiHolde
 internal fun LifecycleOwner.createDataSources(context: Context): ApiHolder =
     when (this) {
         is ComponentActivity -> createDataSources()
+        is Fragment -> requireActivity().createDataSources()
         else -> context.createDataSources()
     }
 

--- a/locationfetcher/src/main/java/com/freelapp/libs/locationfetcher/impl/util/ActivityRequester.kt
+++ b/locationfetcher/src/main/java/com/freelapp/libs/locationfetcher/impl/util/ActivityRequester.kt
@@ -5,6 +5,7 @@ import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.Fragment
 
 internal typealias ResolutionResolver = ActivityResultLauncher<IntentSenderRequest>
 internal typealias PermissionRequester = ActivityResultLauncher<Array<String>>
@@ -17,6 +18,20 @@ internal inline fun ComponentActivity.resolutionResolver(
     }
 
 internal inline fun ComponentActivity.permissionRequester(
+    crossinline block: (Map<String, Boolean>) -> Unit
+): ActivityResultLauncher<Array<String>> =
+    registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
+        block(it.toMap())
+    }
+
+internal inline fun Fragment.resolutionResolver(
+    crossinline block: (ActivityResult) -> Unit
+): ActivityResultLauncher<IntentSenderRequest> =
+    registerForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) {
+        block(it)
+    }
+
+internal inline fun Fragment.permissionRequester(
     crossinline block: (Map<String, Boolean>) -> Unit
 ): ActivityResultLauncher<Array<String>> =
     registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven(url = "https://jitpack.io")
     }
 }
 rootProject.name = "LocationFetcher"


### PR DESCRIPTION
- Add support for `Fragment` alongside the
  already supported `ComponentActivity` and `Context`.

- Add builders with support for lazy rationales.

  These builders allow building `LocationFetcher` passing in
  a rationale producer instead of a rationale string.
  This enables the possibility for using `getString` in
  a field assignment in a `ComponentActivity`/`Fragment`:
  
  ```kotlin
  class MyFragment : Fragment() {
      private val locationFetcher = 
          locationFetcher({ getString(R.string.rationale) }) {
              // ... config
          }
  }
  ```
  
- Bump versions:

  Kotlin: 1.6.0-RC2 -> 1.6.10
  
  `com.android.library`: 7.1.0-beta02 -> 7.1.2
  `kotlinx.coroutines`: 1.5.2 -> 1.6.0
  `play-services-location`: 18.0.0 -> 19.0.1
  `activity-ktx`: 1.4.0-rc01 -> 1.4.0
  `fragment-ktx`: 1.4.0-rc01 -> 1.4.1
  `appcompat`: 1.4.0-rc01 -> 1.4.1
  `lifecycle`: 2.4.0 -> 2.4.1